### PR TITLE
Convert "Product" layout title to rich text content area.

### DIFF
--- a/layouts/product.tpl
+++ b/layouts/product.tpl
@@ -77,7 +77,7 @@
               <div class="content-body-inner">
                 <header class="content-header">
                   <div class="content-area">
-                    <h1 class="content-item-title">{% contentblock name="content_header" publish_default_content="true" single="plaintext" %}{{ page.title }}{% endcontentblock %}</h1>
+                    <div class="content-item-title">{% contentblock name="content_header_test" publish_default_content="true" %}<h1>{{ page.title }}</h1>{% endcontentblock %}</div>
                   </div>
                 </header>
 


### PR DESCRIPTION
(Issue: #147)

- [x] Change the plain text content title area to fully functional wysihtml editor area.

Related issue: https://github.com/Edicy/operations/issues/129